### PR TITLE
Plumb parsed graph id through to graphlib's graph label

### DIFF
--- a/lib/build-graph.js
+++ b/lib/build-graph.js
@@ -11,7 +11,7 @@ function buildGraph(parseTree) {
       defaultStack = [{ node: {}, edge: {} }],
       id = parseTree.id,
       g = new Graph({ directed: isDirected, multigraph: isMultigraph, compound: true });
-      g.setGraph(id);
+      g.setGraph({id: id});
   _.each(parseTree.stmts, function(stmt) { handleStmt(g, stmt, defaultStack); });
   return g;
 }

--- a/lib/build-graph.js
+++ b/lib/build-graph.js
@@ -9,8 +9,9 @@ function buildGraph(parseTree) {
   var isDirected = parseTree.type !== "graph",
       isMultigraph = !parseTree.strict,
       defaultStack = [{ node: {}, edge: {} }],
+      id = parseTree.id,
       g = new Graph({ directed: isDirected, multigraph: isMultigraph, compound: true });
-      g.setGraph({});
+      g.setGraph(id);
   _.each(parseTree.stmts, function(stmt) { handleStmt(g, stmt, defaultStack); });
   return g;
 }

--- a/lib/build-graph.js
+++ b/lib/build-graph.js
@@ -11,7 +11,7 @@ function buildGraph(parseTree) {
       defaultStack = [{ node: {}, edge: {} }],
       id = parseTree.id,
       g = new Graph({ directed: isDirected, multigraph: isMultigraph, compound: true });
-      g.setGraph({id: id});
+      g.setGraph(id == null ? {} : {id: id});
   _.each(parseTree.stmts, function(stmt) { handleStmt(g, stmt, defaultStack); });
   return g;
 }

--- a/test/read-one-test.js
+++ b/test/read-one-test.js
@@ -35,11 +35,11 @@ describe("read", function() {
       expect(g.isDirected()).to.be.true;
     });
 
-    it("safely ignores the id for the graph", function() {
+    it("safely incorporates the id for the graph", function() {
       var g = read("digraph foobar {}");
       expect(g.nodeCount()).to.equal(0);
       expect(g.edgeCount()).to.equal(0);
-      expect(g.graph()).to.eql({});
+      expect(g.graph()).to.eql({id: 'foobar'});
       expect(g.isDirected()).to.be.true;
     });
 


### PR DESCRIPTION
This is useful when invoking readMany(), as each graph then has a label that matches that in the dotfile.