### PR TITLE
writing compound attribute to dot output, if graph is compound

### DIFF
--- a/lib/write-one.js
+++ b/lib/write-one.js
@@ -14,6 +14,10 @@ function writeOne(g) {
 
   writer.writeLine((g.isDirected() ? "digraph" : "graph") + " {");
   writer.indent();
+  
+  if (g.isCompound()) {
+    writer.writeLine("compound=true;") 
+  }
 
   var graphAttrs = g.graph();
   if (_.isObject(graphAttrs)) {


### PR DESCRIPTION
This appears to be required for dot to correctly render a compound graph