### PR TITLE
Fix CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "parse"
   ],
   "dependencies": {
-    "graphlib": "^1.0.1",
+    "graphlib": "^2.1.1",
     "lodash": "^2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update `graphlib`, as the version of `lodash` the current one is using appears to have changed the meaning of paths with dots in them... This has been addressed, but it appears not in the older version used here.

----

Anyways, More details:

The bug above essentially resulted in `_.has(obj, '12.')` === `_.has(obj, '12')`, which causes the node of id `12` and the node of id `12.` to be considered the same.

Parts of graphlib affected (before lodash upgrade):

* https://github.com/cpettitt/graphlib/blob/master/lib/graph.js#L140
* https://github.com/cpettitt/graphlib/blob/master/lib/graph.js#L166
* https://github.com/cpettitt/graphlib/blob/master/lib/graph.js#L171

Example failure output: https://travis-ci.org/cpettitt/graphlib-dot/builds/156226485